### PR TITLE
Update puppet agent, puppet-termini and terraform

### DIFF
--- a/build_versions.json
+++ b/build_versions.json
@@ -2,17 +2,17 @@
   "include": [
     {
       "puppet_release": 7,
-      "puppet_version": "7.27.0",
-      "puppetdb_termini_version": "7.15.0",
-      "terraform_version": "1.6.6",
+      "puppet_version": "7.28.0",
+      "puppetdb_termini_version": "7.16.0",
+      "terraform_version": "1.7.1",
       "pdk_version": "3.0.1.3",
       "bolt_version": "3.27.4"
     },
     {
       "puppet_release": 8,
-      "puppet_version": "8.3.1",
-      "puppetdb_termini_version": "8.2.0",
-      "terraform_version": "1.6.6",
+      "puppet_version": "8.4.0",
+      "puppetdb_termini_version": "8.3.0",
+      "terraform_version": "1.7.1",
       "pdk_version": "3.0.1.3",
       "bolt_version": "3.27.4"
     }


### PR DESCRIPTION
puppet agent to 7.28.0 and 8.4.0
puppet-termini to 7.16.0 and 8.3.0
terraform to 1.7.1