### PR TITLE
Add rubygems for module testing

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -41,7 +41,14 @@ jobs:
             PDK_VERSION=${{ matrix.pdk_version }}
             BOLT_VERSION=${{ matrix.bolt_version }}
             PUPPETDB_TERMINI_VERSION=${{ matrix.puppetdb_termini_version }}
-          # we can not yet build arm containers as pdk and bolt are not available for arm
+            RUBYGEM_BUNDLER=${{ matrix.rubygem_bundler }}
+            RUBYGEM_VOXPUPULI_TEST=${{ matrix.rubygem_voxpupuli_test }}
+            RUBYGEM_VOXPUPULI_ACCEPTANCE=${{ matrix.rubygem_voxpupuli_acceptance }}
+            RUBYGEM_VOXPUPULI_RELEASE=${{ matrix.rubygem_voxpupuli_release }}
+            RUBYGEM_PUPPET_METADATA=${{ matrix.rubygem_puppet_metadata }}
+            RUBYGEM_OVERCOMMIT=${{ matrix.rubygem_overcommit }}
+            RUBYGEM_PUPPET=${{ matrix.rubygem_puppet }}
+            # we can not yet build arm containers as pdk and bolt are not available for arm
           # build_arch: linux/amd64,linux/arm64
           docker_username: ${{ vars.DOCKERHUB_USER }}
           docker_password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,10 +20,10 @@ ARG PUPPET_RELEASE
 ENV PUPPET_RELEASE=${PUPPET_RELEASE:-7}
 
 ARG PUPPET_VERSION
-ENV PUPPET_VERSION=${PUPPET_VERSION:-7.27.0}
+ENV PUPPET_VERSION=${PUPPET_VERSION:-7.29.1}
 
 ARG TERRAFORM_VERSION
-ENV TERRAFORM_VERSION=${TERRAFORM_VERSION:-1.6.2}
+ENV TERRAFORM_VERSION=${TERRAFORM_VERSION:-1.7.4}
 
 ARG PDK_VERSION
 ENV PDK_VERSION=${PDK_VERSION:-3.0.1.3}
@@ -33,6 +33,27 @@ ENV BOLT_VERSION=${BOLT_VERSION:-3.27.4}
 
 ARG PUPPETDB_TERMINI_VERSION
 ENV PUPPETDB_TERMINI_VERSION=${PUPPETDB_TERMINI_VERSION:-7.15.0}
+
+ARG RUBYGEM_BUNDLER
+ENV RUBYGEM_BUNDLER=${RUBYGEM_BUNDLER:-2.5.6}
+
+ARG RUBYGEM_VOXPUPULI_TEST
+ENV RUBYGEM_VOXPUPULI_TEST=${RUBYGEM_VOXPUPULI_TEST:-7.1.0}
+
+ARG RUBYGEM_VOXPUPULI_ACCEPTANCE
+ENV RUBYGEM_VOXPUPULI_ACCEPTANCE=${RUBYGEM_VOXPUPULI_ACCEPTANCE:-3.0.0}
+
+ARG RUBYGEM_VOXPUPULI_RELEASE
+ENV RUBYGEM_VOXPUPULI_RELEASE=${RUBYGEM_VOXPUPULI_RELEASE:-3.0.1}
+
+ARG RUBYGEM_PUPPET_METADATA
+ENV RUBYGEM_PUPPET_METADATA=${RUBYGEM_PUPPET_METADATA:-3.6.0}
+
+ARG RUBYGEM_OVERCOMMIT
+ENV RUBYGEM_OVERCOMMIT=${RUBYGEM_OVERCOMMIT:-0.63.0}
+
+ARG RUBYGEM_PUPPET
+ENV RUBYGEM_PUPPET=${RUBYGEM_PUPPET:-7.29.1}
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PUPPET_DEB=puppet${PUPPET_RELEASE}-release-${UBUNTU_CODENAME}.deb
@@ -52,11 +73,18 @@ RUN apt update && apt upgrade -y && apt install -y --no-install-recommends \
     puppetdb-termini=${PUPPETDB_TERMINI_VERSION}-1${UBUNTU_CODENAME} \
     unzip \
     yamllint \
+    make \
+    libc-dev \
+    gcc \
+    g++ \
+    ruby3.0 \
+    ruby3.0-dev \
     && apt autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
+    && locale-gen en_US.UTF-8 \
     && /opt/puppetlabs/puppet/bin/puppet module install puppet-catalog_diff \
-    && locale-gen en_US.UTF-8
+    && gem install bundler -v ${RUBYGEM_BUNDLER} --no-document
 
 ADD https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip /terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip
 RUN \
@@ -66,13 +94,15 @@ RUN \
     rm terraform_${TERRAFORM_VERSION}_linux_${TARGETARCH}.zip && \
     terraform --version
 
+COPY pdc/Gemfile /
+COPY Dockerfile /
+
+RUN bundle config set path.system true && \
+    bundle install
+
 ENV BOLT_DISABLE_ANALYTICS=true
-ENV PATH=/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin:$PATH
+ENV PDK_DISABLE_ANALYTICS=true
+ENV PATH=$PATH:/opt/puppetlabs/puppet/bin:/opt/puppetlabs/bin
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en
 ENV LC_ALL en_US.UTF-8
-
-COPY Dockerfile /
-
-# ENTRYPOINT ["/opt/puppetlabs/bin/puppet"]
-# CMD ["agent" "--verbose" "--onetime" "--no-daemonize"

--- a/build_versions.json
+++ b/build_versions.json
@@ -2,19 +2,33 @@
   "include": [
     {
       "puppet_release": 7,
-      "puppet_version": "7.28.0",
-      "puppetdb_termini_version": "7.16.0",
-      "terraform_version": "1.7.2",
+      "puppet_version": "7.29.1",
+      "puppetdb_termini_version": "7.17.1",
+      "terraform_version": "1.7.4",
       "pdk_version": "3.0.1.3",
-      "bolt_version": "3.27.4"
+      "bolt_version": "3.28.0",
+      "rubygem_bundler": "2.5.6",
+      "rubygem_voxpupuli_test": "7.1.0",
+      "rubygem_voxpupuli_acceptance": "3.0.0",
+      "rubygem_voxpupuli_release": "3.0.1",
+      "rubygem_puppet_metadata": "3.6.0",
+      "rubygem_overcommit": "0.63.0",
+      "rubygem_puppet": "7.29.1"
     },
     {
       "puppet_release": 8,
-      "puppet_version": "8.4.0",
-      "puppetdb_termini_version": "8.3.0",
-      "terraform_version": "1.7.2",
+      "puppet_version": "8.5.1",
+      "puppetdb_termini_version": "8.4.1",
+      "terraform_version": "1.7.4",
       "pdk_version": "3.0.1.3",
-      "bolt_version": "3.27.4"
+      "bolt_version": "3.28.0",
+      "rubygem_bundler": "2.5.6",
+      "rubygem_voxpupuli_test": "7.1.0",
+      "rubygem_voxpupuli_acceptance": "3.0.0",
+      "rubygem_voxpupuli_release": "3.0.1",
+      "rubygem_puppet_metadata": "3.6.0",
+      "rubygem_overcommit": "0.63.0",
+      "rubygem_puppet": "7.29.1"
     }
   ]
 }

--- a/pdc/Gemfile
+++ b/pdc/Gemfile
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+# Managed by modulesync - DO NOT EDIT
+# https://voxpupuli.org/docs/updating-files-managed-with-modulesync/
+
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
+
+group :test do
+  gem 'voxpupuli-test', ENV['RUBYGEM_VOXPUPULI_TEST'],   :require => false
+  gem 'coveralls',                  :require => false
+  gem 'simplecov-console',          :require => false
+  gem 'puppet_metadata', ENV['RUBYGEM_PUPPET_METADATA'],  :require => false
+end
+
+group :development do
+  gem 'guard-rake',               :require => false
+  gem 'overcommit', ENV['RUBYGEM_OVERCOMMIT'],  :require => false
+end
+
+group :system_tests do
+  gem 'voxpupuli-acceptance', ENV['RUBYGEM_VOXPUPULI_ACCEPTANCE'],  :require => false
+end
+
+group :release do
+  gem 'voxpupuli-release', ENV['RUBYGEM_VOXPUPULI_RELEASE'],  :require => false
+end
+
+gem 'rake', :require => false
+gem 'facter', ENV['FACTER_GEM_VERSION'], :require => false, :groups => [:test]
+gem 'puppet', ENV['RUBYGEM_PUPPET'], :require => false, :groups => [:test]
+
+# vim: syntax=ruby


### PR DESCRIPTION
- install ruby3.0 and build dependencies
- update puppet version
- update bolt version
- update termini version
- update terraform version

- install gems into system ruby
- install voxpupuli-* gems for module testing

- add gem versions to build_versions.json
- bind variables from build_versions.json into Dockerfile via build_container.yml
- add Gemfile with ENV variable bindings
- set PDK_DISABLE_ANALYTICS

both bundle and system calls should now work

```
root@ac4ba0658900:/# rake --version
rake, version 13.1.0

root@ac4ba0658900:/# bundle exec rake --version
rake, version 13.1.0
```

for voxpupuli style modules, mount code into /repo (f.e.) and execute

```
cd /repo
bundle exec rake validate
```